### PR TITLE
Interpolation Skymap Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.23.1] - 2024-05-14
+
+-Added a new method for finding unofficial skymaps assuming the skymap monotically changes with height
+
 ## [0.23.0] - 2024-04-21
 
 ### Added

--- a/asilib/asi/rego.py
+++ b/asilib/asi/rego.py
@@ -33,7 +33,7 @@ def rego(
     time: utils._time_type = None,
     time_range: utils._time_range_type = None,
     alt: int = 110,
-    custom_alt: bool = False,
+    custom_alt: str = False,
     redownload: bool = False,
     missing_ok: bool = True,
     load_images: bool = True,
@@ -58,12 +58,15 @@ def rego(
         the ASI data time interval.
     alt: int
         The reference skymap altitude, in kilometers.
-    custom_alt: bool
-        If True, asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
+    custom_alt: str, default None
+        When selected, there are two options for skymap's between official sky maps:
+        If 'Geodetic', asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
 
         .. note::
         
             The spherical model of Earth's surface is less accurate than the oblate spheroid geometrical representation. Therefore, there will be a small difference between these and the official skymaps.
+
+        If 'Interp', asilib will calculate the (lat,lon) sky maps assuming that the interpolation between official maps is linear. This was supported by personal conversations with Dr. Eric Donovan of the University of Calgary
     redownload: bool
         If True, will download the data from the internet, regardless of
         wether or not the data exists locally (useful if the data becomes
@@ -159,20 +162,27 @@ def rego(
     _skymap = rego_skymap(location_code, _time, redownload=redownload)
     
     if custom_alt==False:
-        alt_index = np.where(_skymap['FULL_MAP_ALTITUDE'] / 1000 == alt)[0] #Compares the altitudes versus the ones provided by default and chooses the correct index that correlates to the chosen alitudes
+        alt_index = np.where(_skymap['FULL_MAP_ALTITUDE'] / 1e3 == alt)[0]
         assert (
             len(alt_index) == 1
-        ), f'{alt} km is not in the valid skymap altitudes: {_skymap["FULL_MAP_ALTITUDE"]/1000} km. If you want a custom altitude with less percision, please use the custom_alt keyword'
+        ), f'{alt} km is not in the valid skymap altitudes: {_skymap["FULL_MAP_ALTITUDE"]/1e3} km. If you want a custom altitude with less percision, please use the custom_alt keyword'
         alt_index = alt_index[0]
-        lat=_skymap['FULL_MAP_LATITUDE'][alt_index, :, :] #selects lat lon coordinates from data provided in skymap
+        lat=_skymap['FULL_MAP_LATITUDE'][alt_index, :, :]
         lon=_skymap['FULL_MAP_LONGITUDE'][alt_index, :, :]
-    else:
-        lat,lon = asilib.skymap.geodetic_skymap( #Spherical projection for lat lon coordinates
+    elif custom_alt =='geodetic':
+        lat,lon = asilib.skymap.geodetic_skymap(
             (float(_skymap['SITE_MAP_LATITUDE']), float(_skymap['SITE_MAP_LONGITUDE']), float(_skymap['SITE_MAP_ALTITUDE']) / 1e3),
             _skymap['FULL_AZIMUTH'],
             _skymap['FULL_ELEVATION'],
             alt
             )
+    elif custom_alt == 'interp':
+        interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  #Gets the first and second sky map, figures out the slope matrix between the two
+        interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3 , _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  
+        lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) #Uses the first sky map and the slope matrix to find the skymap at the desired output
+        lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) 
+    else:
+        raise ValueError("Please input the skymap method")
 
     skymap = {
         'lat': lat,

--- a/asilib/asi/themis.py
+++ b/asilib/asi/themis.py
@@ -153,7 +153,7 @@ def themis(
             _skymap['FULL_ELEVATION'],
             alt
             )
-    elif custom_alt == 'interp'
+    elif isintance(custom_alt, str) and (custom_alt.lower() =='interp'):
         interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  #Gets the first and second sky map, figures out the slope matrix between the two
         interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3 , _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  
         lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) #Uses the first sky map and the slope matrix to find the skymap at the desired output

--- a/asilib/asi/themis.py
+++ b/asilib/asi/themis.py
@@ -34,7 +34,7 @@ def themis(
     time: utils._time_type = None,
     time_range: utils._time_range_type = None,
     alt: int = 110,
-    custom_alt: bool = False,
+    custom_alt: str = False,
     redownload: bool = False,
     missing_ok: bool = True,
     load_images: bool = True,
@@ -59,7 +59,7 @@ def themis(
         If True, will download the data from the internet, regardless of
         wether or not the data exists locally (useful if the data becomes
         corrupted).
- custom_alt: str, default None
+    custom_alt: str, default None
         When selected, there are two options for skyma's between official sky maps:
         If 'Geodetic', asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
 
@@ -158,7 +158,8 @@ def themis(
         interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3 , _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  
         lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) #Uses the first sky map and the slope matrix to find the skymap at the desired output
         lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) 
-
+    else:
+        raise ValueError("Please input the skymap method")
     skymap = {
         'lat': lat,
         'lon': lon,

--- a/asilib/asi/themis.py
+++ b/asilib/asi/themis.py
@@ -154,10 +154,10 @@ def themis(
             alt
             )
     elif custom_alt == 'interp'
-        interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'] / 1000, _skymap['FULL_MAP_ALTITUDE'] / 1000)  #Get the skymap then interp both
-        interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'] / 1000 , _skymap['FULL_MAP_ALTITUDE'] / 1000)  #Get the skymap then interp both
-        lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'] / 1000, alt)
-        lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'] / 1000, alt)
+        interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  #Gets the first and second sky map, figures out the slope matrix between the two
+        interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3 , _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  
+        lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) #Uses the first sky map and the slope matrix to find the skymap at the desired output
+        lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) 
 
     skymap = {
         'lat': lat,

--- a/asilib/asi/themis.py
+++ b/asilib/asi/themis.py
@@ -59,12 +59,16 @@ def themis(
         If True, will download the data from the internet, regardless of
         wether or not the data exists locally (useful if the data becomes
         corrupted).
-    custom_alt: bool
-        If True, asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
+ custom_alt: str, default None
+        When selected, there are two options for skyma's between official sky maps:
+        If 'Geodetic', asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
 
         .. note::
         
             The spherical model of Earth's surface is less accurate than the oblate spheroid geometrical representation. Therefore, there will be a small difference between these and the official skymaps.
+
+        If 'Interp', asilib will calculate the (lat,lon) sky maps assuming that the interpolation between official maps is linear. This was supported by personal conversations with Dr. Eric Donovan of the University of Calgary
+    redownload: bool
     missing_ok: bool
         Wether to allow missing data files inside time_range (after searching
         for them locally and online).
@@ -135,20 +139,25 @@ def themis(
     _skymap = themis_skymap(location_code, _time, redownload)
 
     if custom_alt==False:
-        alt_index = np.where(_skymap['FULL_MAP_ALTITUDE'] / 1000 == alt)[0] #Compares the altitudes versus the ones provided by default and chooses the correct index that correlates to the chosen alitudes
+        alt_index = np.where(_skymap['FULL_MAP_ALTITUDE'] / 1000 == alt)[0]
         assert (
             len(alt_index) == 1
         ), f'{alt} km is not in the valid skymap altitudes: {_skymap["FULL_MAP_ALTITUDE"]/1000} km. If you want a custom altitude with less percision, please use the custom_alt keyword'
         alt_index = alt_index[0]
-        lat=_skymap['FULL_MAP_LATITUDE'][alt_index, :, :] #selects lat lon coordinates from data provided in skymap
+        lat=_skymap['FULL_MAP_LATITUDE'][alt_index, :, :]
         lon=_skymap['FULL_MAP_LONGITUDE'][alt_index, :, :]
-    else:
-        lat,lon = asilib.skymap.geodetic_skymap( #Spherical projection for lat lon coordinates
+    elif custom_alt =='geodetic':
+        lat,lon = asilib.skymap.geodetic_skymap(
             (float(_skymap['SITE_MAP_LATITUDE']), float(_skymap['SITE_MAP_LONGITUDE']), float(_skymap['SITE_MAP_ALTITUDE']) / 1e3),
             _skymap['FULL_AZIMUTH'],
             _skymap['FULL_ELEVATION'],
             alt
             )
+    elif custom_alt == 'interp'
+        interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'] / 1000, _skymap['FULL_MAP_ALTITUDE'] / 1000)  #Get the skymap then interp both
+        interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'] / 1000 , _skymap['FULL_MAP_ALTITUDE'] / 1000)  #Get the skymap then interp both
+        lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'] / 1000, alt)
+        lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'] / 1000, alt)
 
     skymap = {
         'lat': lat,

--- a/asilib/asi/themis.py
+++ b/asilib/asi/themis.py
@@ -146,7 +146,7 @@ def themis(
         alt_index = alt_index[0]
         lat=_skymap['FULL_MAP_LATITUDE'][alt_index, :, :]
         lon=_skymap['FULL_MAP_LONGITUDE'][alt_index, :, :]
-    elif custom_alt =='geodetic':
+    elif isintance(custom_alt, str) and (custom_alt.lower() =='geodetic'):
         lat,lon = asilib.skymap.geodetic_skymap(
             (float(_skymap['SITE_MAP_LATITUDE']), float(_skymap['SITE_MAP_LONGITUDE']), float(_skymap['SITE_MAP_ALTITUDE']) / 1e3),
             _skymap['FULL_AZIMUTH'],

--- a/asilib/asi/trex.py
+++ b/asilib/asi/trex.py
@@ -500,7 +500,7 @@ def trex_nir(
     time: utils._time_type = None,
     time_range: utils._time_range_type = None,
     alt: int = 110,
-    custom_alt: bool = False,
+    custom_alt: str = False,
     redownload: bool = False,
     missing_ok: bool = True,
     load_images: bool = True,
@@ -527,12 +527,15 @@ def trex_nir(
         the ASI data time interval.
     alt: int
         The reference skymap altitude, in kilometers.
-    custom_alt: bool
-        If True, asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
+    custom_alt: str, default None
+        When selected, there are two options for skyma's between official sky maps:
+        If 'Geodetic', asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
 
         .. note::
         
             The spherical model of Earth's surface is less accurate than the oblate spheroid geometrical representation. Therefore, there will be a small difference between these and the official skymaps.
+
+        If 'Interp', asilib will calculate the (lat,lon) sky maps assuming that the interpolation between official maps is linear. This was supported by personal conversations with Dr. Eric Donvan of the University of Calgary
     redownload: bool
         If True, will download the data from the internet, regardless of
         wether or not the data exists locally (useful if the data becomes
@@ -637,21 +640,28 @@ def trex_nir(
         _time = time_range[0]
     _skymap = trex_nir_skymap(location_code, _time, redownload=redownload)
     
-    if custom_alt==False:
-        alt_index = np.where(_skymap['FULL_MAP_ALTITUDE'] / 1000 == alt)[0] #Compares the altitudes versus the ones provided by default and chooses the correct index that correlates to the chosen alitudes
+        if custom_alt==False:
+        alt_index = np.where(_skymap['FULL_MAP_ALTITUDE'] / 1e3 == alt)[0]
         assert (
             len(alt_index) == 1
-        ), f'{alt} km is not in the valid skymap altitudes: {_skymap["FULL_MAP_ALTITUDE"]/1000} km. If you want a custom altitude with less percision, please use the custom_alt keyword'
+        ), f'{alt} km is not in the valid skymap altitudes: {_skymap["FULL_MAP_ALTITUDE"]/1e3} km. If you want a custom altitude with less percision, please use the custom_alt keyword'
         alt_index = alt_index[0]
-        lat=_skymap['FULL_MAP_LATITUDE'][alt_index, :, :] #selects lat lon coordinates from data provided in skymap
+        lat=_skymap['FULL_MAP_LATITUDE'][alt_index, :, :]
         lon=_skymap['FULL_MAP_LONGITUDE'][alt_index, :, :]
-    else:
-        lat,lon = asilib.skymap.geodetic_skymap( #Spherical projection for lat lon coordinates
+    elif custom_alt =='geodetic':
+        lat,lon = asilib.skymap.geodetic_skymap(
             (float(_skymap['SITE_MAP_LATITUDE']), float(_skymap['SITE_MAP_LONGITUDE']), float(_skymap['SITE_MAP_ALTITUDE']) / 1e3),
             _skymap['FULL_AZIMUTH'],
             _skymap['FULL_ELEVATION'],
             alt
             )
+    elif custom_alt == 'interp':
+        interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  #Gets the first and second sky map, figures out the slope matrix between the two
+        interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3 , _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  
+        lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) #Uses the first sky map and the slope matrix to find the skymap at the desired output
+        lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) 
+    else:
+        raise ValueError("Please input the skymap method")
 
     skymap = {
         'lat': lat,

--- a/asilib/asi/trex.py
+++ b/asilib/asi/trex.py
@@ -71,12 +71,15 @@ def trex_rgb(
         the ASI data time interval.
     alt: int
         The reference skymap altitude, in kilometers.
-    custom_alt: bool
-        If True, asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
+    custom_alt: str, default None
+        When selected, there are two options for skyma's between official sky maps:
+        If 'Geodetic', asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
 
         .. note::
         
             The spherical model of Earth's surface is less accurate than the oblate spheroid geometrical representation. Therefore, there will be a small difference between these and the official skymaps.
+
+        If 'Interp', asilib will calculate the (lat,lon) sky maps assuming that the interpolation between official maps is linear. This was supported by personal conversations with Dr. Eric Donvan of the University of Calgary
     redownload: bool
         If True, will download the data from the internet, regardless of
         wether or not the data exists locally (useful if the data becomes
@@ -178,6 +181,7 @@ def trex_rgb(
     else:
         _time = time_range[0]
     _skymap = trex_rgb_skymap(location_code, _time, redownload=redownload)
+
     if custom_alt==False:
         alt_index = np.where(_skymap['FULL_MAP_ALTITUDE'] / 1000 == alt)[0]
         assert (
@@ -186,13 +190,18 @@ def trex_rgb(
         alt_index = alt_index[0]
         lat=_skymap['FULL_MAP_LATITUDE'][alt_index, :, :]
         lon=_skymap['FULL_MAP_LONGITUDE'][alt_index, :, :]
-    else:
+    elif custom_alt =='geodetic':
         lat,lon = asilib.skymap.geodetic_skymap(
             (float(_skymap['SITE_MAP_LATITUDE']), float(_skymap['SITE_MAP_LONGITUDE']), float(_skymap['SITE_MAP_ALTITUDE']) / 1e3),
             _skymap['FULL_AZIMUTH'],
             _skymap['FULL_ELEVATION'],
             alt
             )
+    elif custom_alt == 'interp'
+        interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'] / 1000, _skymap['FULL_MAP_ALTITUDE'] / 1000)  #Get the skymap then interp both
+        interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'] / 1000 , _skymap['FULL_MAP_ALTITUDE'] / 1000)  #Get the skymap then interp both
+        lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'] / 1000, alt)
+        lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'] / 1000, alt)
 
     skymap = {
         'lat': lat,

--- a/asilib/asi/trex.py
+++ b/asilib/asi/trex.py
@@ -79,7 +79,7 @@ def trex_rgb(
         
             The spherical model of Earth's surface is less accurate than the oblate spheroid geometrical representation. Therefore, there will be a small difference between these and the official skymaps.
 
-        If 'Interp', asilib will calculate the (lat,lon) sky maps assuming that the interpolation between official maps is linear. This was supported by personal conversations with Dr. Eric Donvan of the University of Calgary
+        If 'Interp', asilib will calculate the (lat,lon) sky maps assuming that the interpolation between official maps is linear. This was supported by personal conversations with Dr. Eric Donovan of the University of Calgary
     redownload: bool
         If True, will download the data from the internet, regardless of
         wether or not the data exists locally (useful if the data becomes
@@ -198,10 +198,10 @@ def trex_rgb(
             alt
             )
     elif custom_alt == 'interp'
-        interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'] / 1000, _skymap['FULL_MAP_ALTITUDE'] / 1000)  #Get the skymap then interp both
-        interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'] / 1000 , _skymap['FULL_MAP_ALTITUDE'] / 1000)  #Get the skymap then interp both
-        lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'] / 1000, alt)
-        lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'] / 1000, alt)
+        interp_lat = utils.calculate_slope(_skymap['FULL_MAP_LATITUDE'][0, :, :], _skymap['FULL_MAP_LATITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  #Gets the first and second sky map, figures out the slope matrix between the two
+        interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3 , _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  
+        lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) #Uses the first sky map and the slope matrix to find the skymap at the desired output
+        lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) 
 
     skymap = {
         'lat': lat,

--- a/asilib/asi/trex.py
+++ b/asilib/asi/trex.py
@@ -41,7 +41,7 @@ def trex_rgb(
     time: utils._time_type = None,
     time_range: utils._time_range_type = None,
     alt: int = 110,
-    custom_alt: bool = False,
+    custom_alt: str = False,
     redownload: bool = False,
     missing_ok: bool = True,
     load_images: bool = True,
@@ -71,7 +71,7 @@ def trex_rgb(
         the ASI data time interval.
     alt: int
         The reference skymap altitude, in kilometers.
-    custom_alt: str, default None
+    custom_alt: str, default False
         When selected, there are two options for skyma's between official sky maps:
         If 'Geodetic', asilib will calculate (lat, lon) skymaps assuming a spherical Earth. Otherwise, it will use the official skymaps (Courtesy of University of Calgary).
 
@@ -202,7 +202,8 @@ def trex_rgb(
         interp_lon = utils.calculate_slope(_skymap['FULL_MAP_LONGITUDE'][0, :, :], _skymap['FULL_MAP_LONGITUDE'][1, :, :], _skymap['FULL_MAP_ALTITUDE'][0] / 1e3 , _skymap['FULL_MAP_ALTITUDE'][1] / 1e3)  
         lat = utils.interpolate_matrix(_skymap['FULL_MAP_LATITUDE'][0, :, :], interp_lat,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) #Uses the first sky map and the slope matrix to find the skymap at the desired output
         lon = utils.interpolate_matrix(_skymap['FULL_MAP_LONGITUDE'][0, :, :], interp_lon,  _skymap['FULL_MAP_ALTITUDE'][0] / 1e3, alt) 
-
+    else:
+        raise ValueError("Please input the skymap method")
     skymap = {
         'lat': lat,
         'lon': lon,

--- a/asilib/tests/test_skymap.py
+++ b/asilib/tests/test_skymap.py
@@ -29,6 +29,12 @@ def test_geodetic_skymap():
         )
     asi._pcolormesh_nan(asi.skymap['lon'], asi.skymap['lat'], asi.skymap['lat'], ax[1])
     return
+@matplotlib.testing.decorators.image_comparison(
+    baseline_images=['test_interp_skymap'],
+    tol=20,
+    remove_text=True,
+    extensions=['png'],
+)
 def test_interp_skymap():
     time = '2020-01-01'
     ref_asi = asilib.asi.themis('GILL', time=time, load_images=False, alt=150)

--- a/asilib/tests/test_skymap.py
+++ b/asilib/tests/test_skymap.py
@@ -9,13 +9,30 @@ import matplotlib.pyplot as plt
     remove_text=True,
     extensions=['png'],
 )
+@matplotlib.testing.decorators.image_comparison(
+    baseline_images=['test_interp_skymap'],
+    tol=20,
+    remove_text=True,
+    extensions=['png'],
+)
 def test_geodetic_skymap():
     """
     Compare the (lat, lon) skymaps between the asilib and the official implementation.
     """
     time = '2020-01-01'
     ref_asi = asilib.asi.themis('GILL', time=time, load_images=False, alt=110)
-    asi = asilib.asi.themis('GILL', time=time, load_images=False, custom_alt=True, alt=110)
+    asi = asilib.asi.themis('GILL', time=time, load_images=False, custom_alt='geodetic', alt=110)
+
+    fig, ax = plt.subplots(2, sharex=True, sharey=True, figsize=(4, 8))
+    ref_asi._pcolormesh_nan(
+        ref_asi.skymap['lon'], ref_asi.skymap['lat'], ref_asi.skymap['lat'], ax[0]
+        )
+    asi._pcolormesh_nan(asi.skymap['lon'], asi.skymap['lat'], asi.skymap['lat'], ax[1])
+    return
+def test_interp_skymap():
+    time = '2020-01-01'
+    ref_asi = asilib.asi.themis('GILL', time=time, load_images=False, alt=150)
+    asi = asilib.asi.themis('GILL', time=time, load_images=False, custom_alt='interp', alt=150)
 
     fig, ax = plt.subplots(2, sharex=True, sharey=True, figsize=(4, 8))
     ref_asi._pcolormesh_nan(

--- a/asilib/utils.py
+++ b/asilib/utils.py
@@ -145,3 +145,11 @@ def progressbar(iterator: Iterable, iter_length: int = None, text: str = None):
             yield item
     finally:
         print()  # end with a newline.
+        
+def calculate_slope(A, B, alt1, alt2): # For skymap Interpolation
+    # Calculate the slope matrix
+    return (B - A) / (alt2 - alt1)
+
+def interpolate_matrix(A, slopes, alt1, alt): #For sky map Interpolation
+    # Interpolate or extrapolate to find the matrix at time t
+    return A + slopes * (alt - alt1)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the contribution guide https://aurora-asi-lib.readthedocs.io/en/latest/contribute.html
-->


## PR summary
This pull request implements a new skymap method for "unofficial altitudes". During discussions during DASP, it was made known to me that the skymap's monotonically increase with height so a simple interpolation is all that is required to find intermediate skymap altitudes. In the skymap test we use the themsis skymap altitudes at 90km and 110km to perfectly recreate the 150km skymap (official). 
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ yes] New and changed code is tested
- [N/A ] *Plotting related* features are demonstrated in an [example](https://github.com/mshumko/asilib/blob/main/docs/examples.rst).
- [yes ] Changes are recorded in `CHANGELOG.md` and [formatted]([url](https://keepachangelog.com/)).
- [ Can document but don't know where, should create new file?] Except bugfies, the changes are [documentated](https://github.com/mshumko/asilib/tree/main/docs). 
