### PR TITLE
Rgbnormalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 - Removed color_brighten kwarg
-- Added a function called _rgb_normalization to normalize rgb images
+- Added a function called _rgb_normalization in imager.py to normalize rgb images
   
 ## [0.24.0] - 2024-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 - Removed color_brighten kwarg
-- Added rgb normalization to images
+- Added a function called _rgb_normalization to normalize rgb images
   
 ## [0.24.0] - 2024-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.25.0] - 2024-07-30
+
+### Changed
+- Removed color_brighten kwarg
+- Added rgb normalization to images
+  
 ## [0.24.0] - 2024-07-22
 
 ### Changed

--- a/asilib/imager.py
+++ b/asilib/imager.py
@@ -86,7 +86,6 @@ class Imager:
         color_map: str = None,
         color_bounds: List[float] = None,
         color_norm: str = None,
-        color_brighten: bool = True,
         azel_contours: bool = False,
         azel_contour_color: str = 'yellow',
         cardinal_directions: str = 'NE',
@@ -112,9 +111,6 @@ class Imager:
             the color normalization will be taken from the ASI array (if specified), and if not
             specified it will default to logarithmic. The norm is not applied to RGB images (see 
             `matplotlib.pyplot.imshow <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_)
-        color_brighten: bool
-            If True, scales the RGB intensities from min(image)-max(image) to 0-1 range. This 
-            results in brighter colors. This is only applied to RGB images.
         azel_contours: bool
             Superpose azimuth and elevation contours on or off.
         azel_contour_color: str
@@ -201,9 +197,6 @@ class Imager:
             the color normalization will be taken from the ASI array (if specified), and if not
             specified it will default to logarithmic. The norm is not applied to RGB images (see 
             `matplotlib.pyplot.imshow <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_)
-        color_brighten: bool
-            If True, scales the RGB intensities from min(image)-max(image) to 0-1 range. This 
-            results in brighter colors. This is only applied to RGB images.
         azel_contours: bool
             Superpose azimuth and elevation contours on or off.
         azel_contour_color: str
@@ -260,7 +253,6 @@ class Imager:
         color_map: str = None,
         color_bounds: List[float] = None,
         color_norm: str = None,
-        color_brighten: bool = True,
         azel_contours: bool = False,
         azel_contour_color: str = 'yellow',
         cardinal_directions: str = 'NE',
@@ -299,9 +291,6 @@ class Imager:
             the color normalization will be taken from the ASI array (if specified), and if not
             specified it will default to logarithmic. The norm is not applied to RGB images (see 
             `matplotlib.pyplot.imshow <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_)
-        color_brighten: bool
-            If True, scales the RGB intensities from min(image)-max(image) to 0-1 range. This 
-            results in brighter colors. This is only applied to RGB images.
         azel_contours: bool
             Superpose azimuth and elevation contours on or off.
         azel_contour_color: str
@@ -441,7 +430,6 @@ class Imager:
         color_map: str = None,
         color_bounds: List[float] = None,
         color_norm: str = None,
-        color_brighten: bool = True,
         min_elevation: float = 10,
         asi_label: bool = True,
         pcolormesh_kwargs: dict = {},
@@ -474,9 +462,6 @@ class Imager:
             the color normalization will be taken from the ASI array (if specified), and if not
             specified it will default to logarithmic. The norm is not applied to RGB images (see 
             `matplotlib.pyplot.imshow <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_)
-        color_brighten: bool
-            If True, scales the RGB intensities from min(image)-max(image) to 0-1 range. This 
-            results in brighter colors. This is only applied to RGB images.
         min_elevation: float
             Masks the pixels below min_elevation degrees.
         asi_label: bool
@@ -606,9 +591,6 @@ class Imager:
             the color normalization will be taken from the ASI array (if specified), and if not
             specified it will default to logarithmic. The norm is not applied to RGB images (see 
             `matplotlib.pyplot.imshow <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_)
-        color_brighten: bool
-            If True, scales the RGB intensities from min(image)-max(image) to 0-1 range. This 
-            results in brighter colors. This is only applied to RGB images.
         azel_contours: bool
             Superpose azimuth and elevation contours on or off.
         azel_contour_color: str
@@ -660,7 +642,6 @@ class Imager:
         color_map: str = None,
         color_bounds: List[float] = None,
         color_norm: str = None,
-        color_brighten: bool = True,
         min_elevation: float = 10,
         pcolormesh_kwargs: dict = {},
         asi_label: bool = True,
@@ -709,9 +690,6 @@ class Imager:
             the color normalization will be taken from the ASI array (if specified), and if not
             specified it will default to logarithmic. The norm is not applied to RGB images (see 
             `matplotlib.pyplot.imshow <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_)
-        color_brighten: bool
-            If True, scales the RGB intensities from min(image)-max(image) to 0-1 range. This 
-            results in brighter colors. This is only applied to RGB images.
         min_elevation: float
             Masks the pixels below min_elevation degrees.
         pcolormesh_kwargs: dict
@@ -962,7 +940,6 @@ class Imager:
         color_map: str = None,
         color_bounds: List[float] = None,
         color_norm: str = None,
-        color_brighten: bool = True,
         pcolormesh_kwargs={},
     ) -> Tuple[plt.Axes, matplotlib.collections.QuadMesh]:
         """
@@ -995,9 +972,6 @@ class Imager:
             the color normalization will be taken from the ASI array (if specified), and if not
             specified it will default to logarithmic. The norm is not applied to RGB images (see 
             `matplotlib.pyplot.imshow <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_)
-        color_brighten: bool
-            If True, scales the RGB intensities from min(image)-max(image) to 0-1 range. This 
-            results in brighter colors. This is only applied to RGB images.
         pcolormesh_kwargs: dict
             A dictionary of keyword arguments (kwargs) to pass directly into
             plt.pcolormesh.
@@ -1455,6 +1429,7 @@ class Imager:
         """
         # Check the plot_settings dict and fall back to a default if user did not specify
         # color_bounds in the method call.
+
         if color_bounds is None:
             # Is it part of the plot_settings generated by the ASI data loader?
             if 'color_bounds' in self.plot_settings.keys():
@@ -1794,7 +1769,6 @@ class Imager:
         ax,
         cmap=None,
         norm=None,
-        color_brighten: bool = True,
         pcolormesh_kwargs={},
     ):
         """
@@ -1848,9 +1822,10 @@ class Imager:
         
         if len(self.meta['resolution']) == 3: #tests to see if the colors selected for an rgb image are rgb or rb or something else
             image = self._rgb_replacer(image)
-            if color_brighten:
-                image = image / np.max(image)
-            
+            #Now we need to normalize the rgb image since it can't do it
+            temp_img = np.clip(image, norm.vmin, norm.vmax) #Normalizes data
+            image = (temp_img - norm.vmin) / (norm.vmax - norm.vmin) #Scales data from 0-1
+
         p = ax.pcolormesh(
             x,
             y,

--- a/asilib/imager.py
+++ b/asilib/imager.py
@@ -163,7 +163,7 @@ class Imager:
 
         if len(self.meta['resolution']) == 3:  # tests if rgb
             image = self._rgb_replacer(image)
-            image = self._rgb_normalization(image, color_norm)
+            image = self._rgb_normalization(image, color_norm.vmin, color_norm.vmax)
 
         im = ax.imshow(image, cmap=color_map, norm=color_norm, origin="lower")
         if label:
@@ -394,7 +394,7 @@ class Imager:
             
             if len(self.meta['resolution']) == 3:  # tests if rgb
                 image = self._rgb_replacer(image)
-                image = self._rgb_normalization(image, color_norm)
+                image = self._rgb_normalization(image, _color_norm.vmin, _color_norm.vmax)
 
             im = ax.imshow(image, cmap=_color_map, norm=_color_norm, origin='lower')
             if label:
@@ -1022,7 +1022,7 @@ class Imager:
         # Same as transpose, but correctly handles RGB keograms.
         _keogram = np.swapaxes(_keogram, 1, 0)
         if len(_keogram.shape) == 3:
-            _keogram =  self._rgb_normalization(_keogram, _color_norm)
+            _keogram =  self._rgb_normalization(_keogram, _color_norm.vmin, _color_norm.vmax)
 
         pcolormesh_obj = ax.pcolormesh(
             _keogram_time,
@@ -1818,7 +1818,7 @@ class Imager:
         
         if len(self.meta['resolution']) == 3: #tests to see if the colors selected for an rgb image are rgb or rb or something else
             image = self._rgb_replacer(image)
-            image=  self._rgb_normalization(image, norm)
+            image = self._rgb_normalization(image, norm.vmin, norm.vmax)
 
         p = ax.pcolormesh(
             x,
@@ -1831,15 +1831,17 @@ class Imager:
         )
         return p
 
-    def _rgb_normalization(rgbarray,norm):
+    def _rgb_normalization(self, rgbarray,vmin, vmax):
         """
         rgbarray, np.array
             Takes an array of rgb values
-        norm, mcolors.Normalize
-            Normalization object that is used for min and max values
+        vmin, float
+            Minimum for normalization
+        vmax, float
+            maximum for normalization
         """
-        temp_img = np.clip(rgbarray, norm.vmin, norm.vmax) #Normalizes data
-        return (temp_img - norm.vmin) / (norm.vmax - norm.vmin) #Scales data from 0-1
+        temp_img = np.clip(rgbarray, vmin, vmax) #Normalizes data
+        return (temp_img - vmin) / (vmax - vmin) #Scales data from 0-1
 
 def _haversine(
     lat1: np.array, lon1: np.array, lat2: np.array, lon2: np.array, r: float = 1


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the contribution guide https://aurora-asi-lib.readthedocs.io/en/latest/contribute.html
-->

## PR summary
Address #25 normalization for rgb images, turns 
![image](https://github.com/user-attachments/assets/dae3b3a2-84d0-43bb-81c4-05399bf0f354)
 to
![image](https://github.com/user-attachments/assets/1bb1317d-f77f-46ae-9989-4ea0c7e59517)
to replicate the behaviour of UofC crib sheets. Additionally removed the color_brighten kwarg as I think its unneeded and already built into the function

-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [#25  ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [Tested with maps, could write a test function though ] New and changed code is tested
- [ Affects Animate Mosaic, does it need to be rerun ?] *Plotting related* features are demonstrated in an [example](https://github.com/mshumko/asilib/blob/main/docs/examples.rst).
- [yup ] Changes are recorded in `CHANGELOG.md` and [formatted]([url](https://keepachangelog.com/)).
- [ ] Except bugfies, the changes are [documentated](https://github.com/mshumko/asilib/tree/main/docs). 

